### PR TITLE
Adding random tournament.

### DIFF
--- a/tweet.py
+++ b/tweet.py
@@ -1,8 +1,8 @@
 import random
 import tweepy
-import csv
 
 from secrets import *
+from numpy import mean
 
 # Mocking matplotlib
 import mock
@@ -16,28 +16,54 @@ for mod_name in mock_modules:
 # import the library
 import axelrod
 
-# Parameters
-rounds = 10
-symbol_pairs = [["C", "D"]] * 4 + \
-               [["😇 ", "😡 "]]
 
-# Create and play the match
-players = [s() for s in random.sample(axelrod.strategies, 2)]
-symbols = random.choice(symbol_pairs)
-match = axelrod.Match(players, rounds)
-match.play()
-scores = [sum([score[i] for score in match.scores()]) for i in range(2)]
+def tweet_match():
+    """
+    Tweet a random match
+    """
+    # Parameters
+    rounds = 10
+    symbol_pairs = [["C", "D"]] * 4 + \
+                   [["😇 ", "😡 "]]
+    players = [s() for s in random.sample(axelrod.strategies, 2)]
+    symbols = random.choice(symbol_pairs)
+    match = axelrod.Match(players, rounds)
+    match.play()
+    scores = [sum([score[i] for score in match.scores()]) for i in range(2)]
 
-# Write the tweet
-tweet = "{} v {}:".format(players[0],
-                          players[1])
-tweet += "\n\n"
-tweet += match.sparklines(c_symbol=symbols[0], d_symbol=symbols[1])
-tweet += "\n\n"
-tweet += "Score: ({}, {})".format(*scores)
-tweet += "\n\n"
-tweet += "axelrod.readthedocs.org"
+    # Write the tweet
+    tweet = "{} v {}:".format(players[0],
+                              players[1])
+    tweet += "\n\n"
+    tweet += match.sparklines(c_symbol=symbols[0], d_symbol=symbols[1])
+    tweet += "\n\n"
+    tweet += "Score: ({}, {})".format(*scores)
+    tweet += "\n\n"
+    tweet += "axelrod.readthedocs.org"
 
+    return tweet
+
+def tweet_tournament():
+    """
+    Tweet a random tournament
+    """
+    players = [s() for s in random.sample(axelrod.strategies, 3)]
+    tournament = axelrod.Tournament(players)
+    results = tournament.play(progress_bar=False)
+    ranks = results.ranked_names
+    scores = sorted(results.normalised_scores, reverse=True)
+
+    # Write the tweet
+    tweet = "3 player tournament: \n"
+    tweet += "\n"
+    tweet += "1st: {} (Mean score: {:.2f})\n".format(ranks[0], mean(scores[0]))
+    tweet += "2nd: {} ({:.2f})\n".format(ranks[1], mean(scores[1]))
+    tweet += "3rd: {} ({:.2f})\n".format(ranks[2], mean(scores[2]))
+
+    return tweet
+
+tweet_type = random.choice([tweet_tournament, tweet_match])
+tweet = tweet_type()
 # Print tweet to screen
 print(tweet)
 


### PR DESCRIPTION
Every tweet is either a two player match or a 3 player tournament.

```
$ python3.5 tweet.py
3 player tournament:

1st: GTFT: 0.33 (Mean score: 3.00)
2nd: Once Bitten (3.00)
3rd: Cooperator (3.00)

$ python3.5 tweet.py
3 player tournament:

1st: Protected Mind Reader (Mean score: 3.00)
2nd: Raider (2.98)
3rd: Prober (2.97)
```

Had to remove url to docs (which is there for a match tweet) as the length seemed to sometimes going over 140 characters.
